### PR TITLE
fix(network): axios module exports and options defaults

### DIFF
--- a/packages/network/src/axios.js
+++ b/packages/network/src/axios.js
@@ -21,10 +21,12 @@ const deleteReq = async (url, options) => {
     return request(methods.DELETE, url, undefined, options, axios)
 }
 
-export const HttpClient = {
+const HttpClient = {
     get,
     post,
     put,
     patch,
     delete: deleteReq
 }
+
+export default HttpClient

--- a/packages/network/src/base.js
+++ b/packages/network/src/base.js
@@ -33,16 +33,16 @@ const cleanConfigHttp = (source) => {
  * @param [middleware] - This is the fetch function.
  * @returns A function that takes in a config object and returns a promise.
  */
-const request = (method, url, body, options, middleware = fetch) => {
+const request = (method, url, body, options = {}, middleware = fetch) => {
     const dirtyConfig = {
         method,
         url,
         data: body,
-        params: options.params,
-        headers: options.headers,
-        withCredentials: options.withCredentials,
-        responseType: options.responseType,
-        signal: options.signal,
+        params: options?.params,
+        headers: options?.headers,
+        withCredentials: options?.withCredentials,
+        responseType: options?.responseType,
+        signal: options?.signal,
         timeout: 0
     }
 

--- a/packages/network/src/index.js
+++ b/packages/network/src/index.js
@@ -1,2 +1,2 @@
-export * from './axios'
+export { default as HttpClient } from './axios'
 export * from './fetch'


### PR DESCRIPTION
In this MR:

- Change the default exports for the axios module 
- Add the default options to dirtyConfig