### PR TITLE
fix(autocomplete): convert requestOptions on a reference and fix predictions data type 

### DIFF
--- a/.changeset/gentle-foxes-tease.md
+++ b/.changeset/gentle-foxes-tease.md
@@ -1,0 +1,5 @@
+---
+'@ftools-suit/autocomplete': patch
+---
+
+autocomplete: Convert requestOptions to reference and fix types

--- a/packages/autocomplete/src/react.ts
+++ b/packages/autocomplete/src/react.ts
@@ -69,6 +69,7 @@ export default function ({ debounce = 300, defaults = {}, requestOptions = {} }:
                 clearPredictions()
                 return
             }
+            console.log('Hello')
             setPredictions((prevPredictions: Predictions) => ({ ...prevPredictions, isLoading: true }))
             autocompleteRef.current?.getPlacePredictions({ ...requestOptions, input: place }, (data, status) => {
                 setPredictions((prevPredictions: Predictions) => ({ ...prevPredictions, isLoading: false, status: status, data: data ?? [] }))

--- a/packages/autocomplete/src/react.ts
+++ b/packages/autocomplete/src/react.ts
@@ -9,13 +9,13 @@ export type defaultsTypes = {
     shouldPrediction?: boolean
     isLoading?: boolean
     status?: PlacesServiceStatus
-    data?: any[] | AutocompletePredictions
+    data?: AutocompletePredictions[] | any[]
 }
 
 export interface Predictions {
     readonly isLoading: boolean
     readonly status: PlacesServiceStatus
-    data: AutocompletePredictions | any
+    data: AutocompletePredictions[] | any[]
 }
 
 export interface useAutocompleteArgs {
@@ -41,19 +41,18 @@ export default function ({ debounce = 300, defaults = {}, requestOptions = {} }:
         data: defaultData
     } = defaults as defaultsTypes
 
-    const autocompleteRef = useRef<google.maps.places.AutocompleteService>()
-    const [place, setPlaceText] = useState('')
+    const [place, setPlaceText] = useState<string>('')
     const [predictions, setPredictions] = useState<Predictions>({
         isLoading: false,
         status: '',
         data: []
     })
 
+    const autocompleteRef = useRef<google.maps.places.AutocompleteService>()
+    const requestOptionsRef = useRef(requestOptions)
+
     const initMap = useCallback(() => {
-        if (autocompleteRef.current) return
-        if (!gmapsApiIsLoaded(true)) {
-            return
-        }
+        if (autocompleteRef.current || !gmapsApiIsLoaded(true)) return
         const libPlaces = google?.maps?.places
         autocompleteRef.current = new libPlaces.AutocompleteService()
     }, [])
@@ -69,13 +68,12 @@ export default function ({ debounce = 300, defaults = {}, requestOptions = {} }:
                 clearPredictions()
                 return
             }
-            console.log('Hello')
             setPredictions((prevPredictions: Predictions) => ({ ...prevPredictions, isLoading: true }))
-            autocompleteRef.current?.getPlacePredictions({ ...requestOptions, input: place }, (data, status) => {
+            autocompleteRef.current?.getPlacePredictions({ ...requestOptionsRef.current, input: place }, (data, status) => {
                 setPredictions((prevPredictions: Predictions) => ({ ...prevPredictions, isLoading: false, status: status, data: data ?? [] }))
             })
         }, debounce),
-        [clearPredictions, debounce, requestOptions]
+        [clearPredictions, requestOptionsRef]
     )
 
     /* A callback function that is used to set the place value and get predictions. */


### PR DESCRIPTION
This PR can be relationed with:

- convert Request options to a reference to prevent re-definitions
- fix prediction data type

Closes issue #91 